### PR TITLE
FIX false setting "Audio output interface"

### DIFF
--- a/app/libs/runeaudio.php
+++ b/app/libs/runeaudio.php
@@ -1929,7 +1929,8 @@ function wrk_mpdconf($redis, $action, $args = null, $jobID = null)
         case 'writecfg':
             $mpdcfg = $redis->hGetAll('mpdconf');
             $current_out = $redis->Get('ao');
-            if (!$redis->hExists('acards', $current_out)) {
+            // if (!$redis->hExists('acards', $current_out)) {
+            if (!$redis->hExists('acards', $current_out) && ($redis->Get('i2smodule') === 'none')) {
                 $stored_acards = $redis->hKeys('acards');
                 // debug
                 runelog('force audio output', $stored_acards[0]);


### PR DESCRIPTION
FIX false setting "Audio output interface" on mpd-config page after reboot with active i2smodule.
A i2smodule can not dissapear without useraction, so it should be save to test if i2smodule is set at this point.
