### PR TITLE
Hide spotify password in settings page.

### DIFF
--- a/app/settings_ctl.php
+++ b/app/settings_ctl.php
@@ -144,7 +144,7 @@ if (isset($_POST)) {
         }
         if ($_POST['features']['spotify']['enable'] == 1) {
             // create worker job (start mpdscribble)
-            if (($_POST['features']['spotify']['user'] != $redis->hGet('spotify', 'user') OR $_POST['features']['spotify']['pass'] != $redis->hGet('spotify', 'pass')) OR $redis->hGet('spotify', 'enable') != $_POST['features']['spotify']['enable']) {
+            if ($_POST['features']['spotify']['pass'] != '' AND (($_POST['features']['spotify']['user'] != $redis->hGet('spotify', 'user') OR $_POST['features']['spotify']['pass'] != $redis->hGet('spotify', 'pass')) OR $redis->hGet('spotify', 'enable') != $_POST['features']['spotify']['enable'])) {
                 $jobID[] = wrk_control($redis, 'newjob', $data = array('wrkcmd' => 'spotify', 'action' => 'start', 'args' => $_POST['features']['spotify']));
             }
         } else {

--- a/app/templates/settings.php
+++ b/app/templates/settings.php
@@ -241,7 +241,7 @@
                     <div class="form-group">
                         <label class="control-label col-sm-2" for="spotify-pasw">Password</label>
                         <div class="col-sm-10">
-                            <input class="form-control osk-trigger input-lg" type="password" id="spotify_pass" name="features[spotify][pass]" value="<?php echo $this->spotify['pass']; ?>" placeholder="pass" autocomplete="off">
+                            <input class="form-control osk-trigger input-lg" type="password" id="spotify_pass" name="features[spotify][pass]" value="" placeholder="pass" autocomplete="off">
                             <span class="help-block">Insert your Spotify <i>password</i> (case sensitive)</span>
                         </div>
                     </div>


### PR DESCRIPTION
The password is echoed in the password input field. Unfortunately one does not have to be a webdev to find the password in cleartext in the sources. 
It's literally visible for everybody in the network, which is, in our case, a students' flat-sharing community. 